### PR TITLE
Fixes no such file or directory for xsd file

### DIFF
--- a/facturx/facturx.py
+++ b/facturx/facturx.py
@@ -125,7 +125,7 @@ def check_facturx_xsd(
             __name__, 'xsd/factur-x/%s' % xsd_filename)
     elif flavor == 'zugferd':
         xsd_file = resource_filename(
-            __name__, 'xsd/xsd-zugferd/ZUGFeRD1p0.xsd')
+            __name__, 'xsd/zugferd/ZUGFeRD1p0.xsd')
     xsd_etree_obj = etree.parse(open(xsd_file))
     official_schema = etree.XMLSchema(xsd_etree_obj)
     try:


### PR DESCRIPTION
xmlcheck fails with no such file or directory.

```
$ facturx-xmlcheck output/201807-KA01.xml -l debug
2018-07-08 11:37:28,797 [INFO] Factur-X flavor is zugferd (autodetected)
2018-07-08 11:37:28,797 [ERROR] [Errno 2] No such file or directory: '/usr/local/lib/python2.7/dist-packages/facturx/xsd/xsd-z
ugferd/ZUGFeRD1p0.xsd'
```