### PR TITLE
Feature : zugferd 2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,7 @@ Factur-X Python library
 Factur-X is the e-invoicing standard for France and Germany. The Factur-X specifications are available on the `FNFE-MPE website <http://fnfe-mpe.org/factur-x/>`_ in English and French. The Factur-X standard is also called `ZUGFeRD 2.1 in Germany <https://www.ferd-net.de/standards/zugferd-2.1.1/index.html>`_.
 
 The main feature of this Python library is to generate Factur-X invoices from a regular PDF invoice and a Factur-X compliant XML file.
+Also it's possible to choose to generate Factur-x invoices matching the ZUGFeRD 2.0 standard (instead of ZUGFeRD 2.1), even though it's not recommended.
 
 This lib provides additionnal features such as:
 
@@ -55,13 +56,15 @@ All these commande line tools have a **-h** option that explains how to use them
 Webservice
 ==========
 
-This project also provides a webservice to generate a Factur-X invoice from a regular PDF invoice, the *factur-x.xml* file and additional attachments (if any). This webservice runs on Python3 and uses `Flask <https://www.palletsprojects.com/p/flask/>`_. To run the webservice, run **facturx-webservice** available in the *bin* subdirectory of the project. To query the webservice, you must send an **HTTP POST** request in **multipart/form-data** using the following keys:
+This project also provides a webservice to generate a Factur-X invoice from a regular PDF invoice, the *factur-x.xml* file and additional attachments (if any). This webservice runs on Python3 and uses `Flask <https://www.palletsprojects.com/p/flask/>`_. To run the webservice, run **facturx-webservice** available in the *bin* subdirectory of the project. To query the webservice, you must send an **HTTP POST** request at **/generate_facturx** in **multipart/form-data** using the following keys:
 
 * **pdf** -> PDF invoice (required)
 * **xml** -> factur-x.xml file (any profile, required)
 * **attachment1** -> First attachment (optional)
 * **attachment2** -> Second attachment (optional)
 * ...
+
+It's also possible to give the parameter **zugferd_version** in the url (**/generate_facturx?zugferd_version=2.0**) to choose between ZUGFeRD 2.0 and 2.1 (this last one beeing the default value).
 
 It is recommended to run the webservice behind an HTTPS/HTTP proxy such as `Nginx <https://www.nginx.com/>`_ or `Apache <https://httpd.apache.org/>`_. You will certainly have to increase the default maximum upload size (default value is only 1MB under Nginx!): use the parameter **client_max_body_size** for Nginx and **LimitRequestBody** for Apache.
 
@@ -85,6 +88,10 @@ Contributors
 
 Changelog
 =========
+
+* Version 1.13 dated 2020-12-16
+
+  * Allow generating factur-x invoices matching the ZUGFeRD 2.0 standard
 
 * Version 1.12 dated 2020-07-16
 

--- a/bin/facturx-pdfgen
+++ b/bin/facturx-pdfgen
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#! /usr/bin/python
 # -*- coding: utf-8 -*-
 # Copyright 2017-2020 Alexis de Lattre <alexis.delattre@akretion.com>
 

--- a/bin/facturx-pdfgen
+++ b/bin/facturx-pdfgen
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 # Copyright 2017-2020 Alexis de Lattre <alexis.delattre@akretion.com>
 
@@ -6,6 +6,7 @@ from optparse import OptionParser
 import sys
 from facturx import generate_facturx_from_file
 from facturx.facturx import logger
+from facturx.facturx import ZUGFERD_VERSIONS
 import logging
 from os.path import isfile, isdir, basename
 
@@ -18,6 +19,10 @@ options = [
         'action': 'store', 'default': 'info',
         'help': "Set log level. Possible values: debug, info, warn, error. "
         "Default value: info."},
+    {'names': ('-z', '--zugferd-version'), 'dest': 'zugferd_version',
+        'action': 'store', 'default': '2.1',
+        'help': "Choose to match either ZUGFeRD 2.1 or 2.0. "
+        "Default: 2.1"},
     {'names': ('-d', '--disable-xsd-check'), 'dest': 'disable_xsd_check',
         'action': 'store_true', 'default': False,
         'help': "De-activate XML Schema Definition check on Factur-X XML file "
@@ -94,6 +99,9 @@ def main(options, arguments):
     if options.disable_xsd_check:
         check_xsd = False
     pdf_metadata = None
+    if options.zugferd_version not in ZUGFERD_VERSIONS:
+        logger.error('The version %s is not allowed. Exit.', options.zugferd_version)
+        sys.exit(1)
     if (
             options.meta_author or
             options.meta_keywords or
@@ -123,7 +131,7 @@ def main(options, arguments):
         generate_facturx_from_file(
             pdf_filename, xml_file, check_xsd=check_xsd,
             facturx_level=options.facturx_level, pdf_metadata=pdf_metadata,
-            output_pdf_file=facturx_pdf_filename, attachments=attachments)
+            output_pdf_file=facturx_pdf_filename, attachments=attachments, zugferd_version=options.zugferd_version)
     except Exception as e:
         logger.error('Factur-x lib call failed. Error: %s', e)
         sys.exit(1)

--- a/bin/facturx-webservice
+++ b/bin/facturx-webservice
@@ -11,6 +11,7 @@ from flask import Flask, request, send_file
 from tempfile import NamedTemporaryFile
 from facturx import generate_facturx_from_file
 from facturx.facturx import logger as fxlogger
+from facturx.facturx import ZUGFERD_VERSIONS
 from optparse import OptionParser
 import logging
 from logging.handlers import RotatingFileHandler
@@ -21,6 +22,13 @@ app = Flask(__name__)
 
 @app.route('/generate_facturx', methods=['POST'])
 def generate_facturx():
+    zugferd_version = request.args.get('zugferd_version', default=ZUGFERD_VERSIONS[0], type=str)
+    if zugferd_version not in ZUGFERD_VERSIONS:
+        app.logger.warning('The version %s is not allowed. Using %s instead.',
+            zugferd_version, ZUGFERD_VERSIONS[0])
+        zugferd_version = ZUGFERD_VERSIONS[0]
+    app.logger.debug('zugferd_version=%s', zugferd_version)
+
     app.logger.debug('request.files=%s', request.files)
     attachments = {}
     for i in range(MAX_ATTACHMENTS):
@@ -50,7 +58,7 @@ def generate_facturx():
             app.logger.debug('attachments keys=%s', attachments.keys())
             generate_facturx_from_file(
                 pdf_file, xml_byte, output_pdf_file=output_pdf_file.name,
-                attachments=attachments)
+                attachments=attachments, zugferd_version=zugferd_version)
             output_pdf_file.seek(0)
             res = send_file(output_pdf_file.name, as_attachment=True)
             app.logger.info(


### PR DESCRIPTION
Added the possibility to generate factur-x invoices matching ZUGFeRD 2.0 standard.
This is totally deprecated, but it can be useful when working with companies used to ZUGFeRD 2.0 instead of 2.1.