### PR TITLE
Reenable scripts (fix #49).

### DIFF
--- a/facturx/scripts/__init__.py
+++ b/facturx/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Make this a module.

--- a/facturx/scripts/pdfextractxml.py
+++ b/facturx/scripts/pdfextractxml.py
@@ -13,7 +13,7 @@ __date__ = "March 2021"
 __version__ = "0.2"
 
 
-def main(args):
+def pdfextractxml(args):
     if args.log_level:
         log_level = args.log_level.lower()
         log_map = {
@@ -64,7 +64,9 @@ def main(args):
         sys.exit(1)
 
 
-if __name__ == '__main__':
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     usage = "facturx-pdfextractxml <facturx_orderx_file> <xml_file_to_create>"
     epilog = "Author: %s - Version: %s" % (__author__, __version__)
     description = "This extracts the XML file from a Factur-X or Order-X PDF file."
@@ -85,4 +87,12 @@ if __name__ == '__main__':
         "xml_file_to_create",
         help="Filename of the XML file that will be extracted from the PDF")
     args = parser.parse_args()
-    main(args)
+    pdfextractxml(args)
+
+
+def run():
+    if __name__ == '__main__':
+        main()
+
+
+run()

--- a/facturx/scripts/pdfgen.py
+++ b/facturx/scripts/pdfgen.py
@@ -13,7 +13,7 @@ __date__ = "March 2021"
 __version__ = "0.6"
 
 
-def main(args):
+def pdfgen(args):
     if args.log_level:
         log_level = args.log_level.lower()
         log_map = {
@@ -85,7 +85,9 @@ def main(args):
         sys.exit(1)
 
 
-if __name__ == '__main__':
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     usage = "facturx-pdfgen <regular_pdf_file> <xml_file> "\
             "<facturx_orderx_pdf_file> <optional_attachments>"
     epilog = "Author: %s - Version: %s" % (__author__, __version__)
@@ -173,4 +175,12 @@ if __name__ == '__main__':
         "optional_attachments", nargs='*',
         help="Optional list of additionnal attachments")
     args = parser.parse_args()
-    main(args)
+    pdfgen(args)
+
+
+def run():
+    if __name__ == '__main__':
+        main()
+
+
+run()

--- a/facturx/scripts/webservice.py
+++ b/facturx/scripts/webservice.py
@@ -20,6 +20,7 @@ from facturx import generate_from_file
 from facturx.facturx import logger as fxlogger
 import argparse
 import logging
+import sys
 from logging.handlers import RotatingFileHandler
 
 MAX_ATTACHMENTS = 3  # TODO make it a cmd line option
@@ -67,7 +68,9 @@ def generate_facturx():
     return res
 
 
-if __name__ == '__main__':
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     usage = "facturx_webservice.py [options]"
     epilog = "Script written by Alexis de Lattre. "\
         "Published under the BSD licence."
@@ -119,3 +122,11 @@ if __name__ == '__main__':
         app.logger.addHandler(handler)
         app.logger.info('Start webservice to generate Factur-X invoices')
     app.run(debug=args.debug, port=args.port, host=args.host)
+
+
+def run():
+    if __name__ == '__main__':
+        main()
+
+
+run()

--- a/facturx/scripts/xmlcheck.py
+++ b/facturx/scripts/xmlcheck.py
@@ -13,7 +13,7 @@ __date__ = "March 2021"
 __version__ = "0.3"
 
 
-def main(args):
+def xmlcheck(args):
     if args.log_level:
         log_level = args.log_level.lower()
         log_map = {
@@ -43,7 +43,9 @@ def main(args):
         sys.exit(1)
 
 
-if __name__ == '__main__':
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     usage = "facturx-xmlcheck <xml_file>"
     epilog = "Author: %s - Version: %s" % (__author__, __version__)
     description = "This script checks the Factur-X or Order-XML XML against the XML "\
@@ -70,4 +72,12 @@ if __name__ == '__main__':
     parser.add_argument(
         "xml_file", help="Factur-X or Order-X XML file to check")
     args = parser.parse_args()
-    main(args)
+    xmlcheck(args)
+
+
+def run():
+    if __name__ == '__main__':
+        main()
+
+
+run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,21 @@ license = {file = "LICENSE"}
 requires-python = ">=3.7"
 dynamic = ["dependencies"]
 
+[project.optional-dependencies]
+web = [
+    "flask"
+]
+
 [project.urls]
 Homepage = "https://github.com/akretion/factur-x"
 Source = "https://github.com/akretion/factur-x"
 Issues = "https://github.com/akretion/factur-x/issues"
 
-# TODO discover how to make scripts work again
-#[project.scripts]
-#facturx-pdfgen = "bin.facturx-pdfgen:main"
-#facturx-pdfextractxml = "bin.facturx-pdfextractxml:main"
-#facturx-xmlcheck = "bin.facturx-xmlcheck:main"
-#facturx-webservice = "bin.facturx-webservice:main"
+[project.scripts]
+facturx-pdfgen = "facturx.scripts.pdfgen:main"
+facturx-pdfextractxml = "facturx.scripts.pdfextractxml:main"
+facturx-xmlcheck = "facturx.scripts.xmlcheck:main"
+facturx-webservice = "facturx.scripts.webservice:main"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Move the scripts into the `facturx` package to make them callable (and installable) for the build-system. Also add `flask` as extra-dependency named `web`. So, to install everything (including dependencies), you now can do something like `pip install factur-x[web]`.

The scripts now each contain a specific function named after their main purpose, a `main` function and a `run` function that only wraps calls to `main` but might become very helpful for testing.

This is just a suggestion, how to make the scripts working again. Thanks for your package!