### PR TITLE
Allow extraction of XRechnung xml files

### DIFF
--- a/facturx/facturx.py
+++ b/facturx/facturx.py
@@ -51,7 +51,8 @@ logger.setLevel(logging.INFO)
 FACTURX_FILENAME = 'factur-x.xml'
 ZUGFERD_FILENAMES = ['zugferd-invoice.xml', 'ZUGFeRD-invoice.xml']
 ORDERX_FILENAME = 'order-x.xml'
-ALL_FILENAMES = [FACTURX_FILENAME] + ZUGFERD_FILENAMES + [ORDERX_FILENAME]
+XRECHNUNG_FILENAME = 'xrechnung.xml'
+ALL_FILENAMES = [FACTURX_FILENAME] + ZUGFERD_FILENAMES + [ORDERX_FILENAME] + [XRECHNUNG_FILENAME]
 FACTURX_LEVEL2xsd = {
     'minimum': 'facturx-minimum/Factur-X_1.07.2_MINIMUM.xsd',
     'basicwl': 'facturx-basicwl/Factur-X_1.07.2_BASICWL.xsd',
@@ -295,7 +296,7 @@ def _get_embeddedfiles(embeddedfiles_node):
 
 
 def get_facturx_xml_from_pdf(pdf_file, check_xsd=True):
-    filenames = [FACTURX_FILENAME] + ZUGFERD_FILENAMES
+    filenames = [FACTURX_FILENAME] + ZUGFERD_FILENAMES + [XRECHNUNG_FILENAME]
     return get_xml_from_pdf(pdf_file, check_xsd=check_xsd, filenames=filenames)
 
 
@@ -846,9 +847,10 @@ def get_flavor(xml_etree):
 def get_orderx_type(xml_etree):
     if not isinstance(xml_etree, type(etree.Element('pouet'))):
         raise ValueError('xml_etree must be an etree.Element() object')
+    namespaces = get_xml_namespaces('order-x')
     type_code_xpath = \
         "/rsm:SCRDMCCBDACIOMessageStructure/rsm:ExchangedDocument/ram:TypeCode"
-    xpath_res = xml_etree.xpath(type_code_xpath, namespaces=XML_NAMESPACES['order-x'])
+    xpath_res = xml_etree.xpath(type_code_xpath, namespaces=namespaces)
     code = xpath_res and xpath_res[0].text and xpath_res[0].text.strip() or None
     if code not in ORDERX_code2type:
         raise Exception(


### PR DESCRIPTION
Zugferd 2.3 adds a profile XRechnung, I am aware that this project currently doesn't support Zugferd 2.3 but this MR adds the ability to extract the xml files from Zugferd 2.3 documents of the XRechnung type.

The changes to the codebase are trivial so I though there might be interest in supporting this and I needed this feature for some work of mine so I thought I would share.