### PR TITLE
Import fallback for compatibility with Python 3.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,11 +114,17 @@ Contributors
 ============
 
 * Alexis de Lattre <alexis.delattre@akretion.com>
+* Houzéfa Abbasbhay <houzefa.abba@xcg-consulting.fr>
 
 Changelog
 =========
 
 **WARNING** Since release 3.2/3.3, the command line tools (facturx-pdfextractxml, facturx-pdfgen, facturx-xmlcheck, facturx-webservice) are not packaged with the lib any more, because I haven't found how to make it work with pyproject.toml. Help appreciated.
+
+* NEXT
+
+  * Import fallback for compatibility with Python 3.8.
+    Requires `importlib-resources backport <https://pypi.org/project/importlib-resources/>`_ on Python 3.8.
 
 * Version 3.6 dated 2024-12-14
 

--- a/facturx/facturx.py
+++ b/facturx/facturx.py
@@ -34,7 +34,11 @@ from datetime import datetime
 from pypdf import PdfWriter, PdfReader
 from pypdf.generic import DictionaryObject, DecodedStreamObject, \
     NameObject, NumberObject, ArrayObject, IndirectObject, create_string_object
-import importlib.resources
+import importlib.resources as importlib_resources
+try:
+    importlib_resources.files  # added in py3.9
+except AttributeError:
+    import importlib_resources  # py3.8 compat: pip install importlib-resources
 import importlib.metadata
 import os.path
 import mimetypes
@@ -191,7 +195,7 @@ def xml_check_xsd(xml, flavor='autodetect', level='autodetect'):
         xsd_file = 'xsd/%s' % ORDERX_LEVEL2xsd[level]
 
     logger.debug('Using XSD file %s', xsd_file)
-    xsd_etree_obj = etree.parse(importlib.resources.files(__package__)
+    xsd_etree_obj = etree.parse(importlib_resources.files(__package__)
         .joinpath(xsd_file).open())
     official_schema = etree.XMLSchema(xsd_etree_obj)
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pypdf>=3.15.0
 lxml
+
+importlib-resources; python_version<'3.9'


### PR DESCRIPTION
[`importlib.resources.files`](https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files) was added in Python 3.9; to keep compat with 3.8, we rely on https://pypi.org/project/importlib-resources/ when available.