### PR TITLE
Fix resource leak: close file handle in xml_check_xsd

### DIFF
--- a/facturx/facturx.py
+++ b/facturx/facturx.py
@@ -191,8 +191,8 @@ def xml_check_xsd(xml, flavor='autodetect', level='autodetect'):
         xsd_file = 'xsd/%s' % ORDERX_LEVEL2xsd[level]
 
     logger.debug('Using XSD file %s', xsd_file)
-    xsd_etree_obj = etree.parse(
-        importlib_resources.files(__package__).joinpath(xsd_file).open())
+    with importlib_resources.files(__package__).joinpath(xsd_file).open() as xsd_f:
+        xsd_etree_obj = etree.parse(xsd_f)
     official_schema = etree.XMLSchema(xsd_etree_obj)
     try:
         t = etree.parse(BytesIO(xml_bytes))


### PR DESCRIPTION
The file opened via importlib_resources.files().joinpath().open() was passed directly to etree.parse(), which does not close it. This leaks a file descriptor on every call to xml_check_xsd().

Wrap the open() call in a with-statement so the handle is properly closed after parsing.

Closes akretion/factur-x#68